### PR TITLE
Fix issue #12

### DIFF
--- a/docs/validator-set/validator-set.md
+++ b/docs/validator-set/validator-set.md
@@ -20,6 +20,7 @@ cargo run --release \
   --tmp \
   --chain local \
   --validator \
+  --execution=Native \
   --unsafe-ws-external
 ```
 
@@ -35,6 +36,7 @@ cargo run --release \
   --tmp \
   --chain local \
   --validator \
+  --execution=Native \
   --unsafe-ws-external \
   --rpc-methods Unsafe \
   --port 30334 \


### PR DESCRIPTION
Related with #12 

According the runtime execution strategy with the below link, the native code will not be triggered on other validator nodes.
https://substrate.dev/docs/en/knowledgebase/advanced/executor

So we need specific runtime always use native mode when launch nodes. 