### PR TITLE
Add debug feature for vm pallet

### DIFF
--- a/.github/workflows/ssvm.yml
+++ b/.github/workflows/ssvm.yml
@@ -11,7 +11,13 @@ jobs:
     - uses: actions/checkout@v2
     - name: Submodules
       run: git submodule update --init --recursive
+
     - uses: cachix/install-nix-action@v13
       with:
         nix_path: nixpkgs=channel:nixos-unstable
-    - run: nix-shell --run "cargo test"
+
+    - name: Default test
+      run: nix-shell --run "cargo test"
+
+    - name: Test with deubg feature
+      run: nix-shell --run "cargo test --features=debug"

--- a/frame/vm/Cargo.toml
+++ b/frame/vm/Cargo.toml
@@ -37,6 +37,7 @@ rustc-hex = { version = "2.1.0", default-features = false }
 
 [features]
 default = ["std"]
+debug = ["std"]
 std = [
 	"serde",
 	"codec/std",

--- a/frame/vm/src/lib.rs
+++ b/frame/vm/src/lib.rs
@@ -180,6 +180,7 @@ pub mod pallet {
 			T::CallOrigin::ensure_address_origin(&source, origin)?;
 
 			// Disable the call from polkadot.js
+			#[cfg(not(feature = "debug"))]
 			ensure!(false, Error::<T>::Forbidden);
 
 			let info = T::Runner::call(
@@ -226,6 +227,7 @@ pub mod pallet {
 			T::CallOrigin::ensure_address_origin(&source, origin)?;
 
 			// Disable the call from polkadot.js
+			#[cfg(not(feature = "debug"))]
 			ensure!(false, Error::<T>::Forbidden);
 
 			let info = T::Runner::create(
@@ -283,6 +285,7 @@ pub mod pallet {
 			T::CallOrigin::ensure_address_origin(&source, origin)?;
 
 			// Disable the call from polkadot.js
+			#[cfg(not(feature = "debug"))]
 			ensure!(false, Error::<T>::Forbidden);
 
 			let info = T::Runner::create2(

--- a/frame/vm/src/tests.rs
+++ b/frame/vm/src/tests.rs
@@ -170,8 +170,37 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	t.into()
 }
 
+#[cfg(feature = "debug")]
 #[test]
 fn fail_call_return_ok() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(EVM::call(
+			Origin::root(),
+			H160::default(),
+			H160::from_str("1000000000000000000000000000000000000001").unwrap(),
+			Vec::new(),
+			U256::default(),
+			1000000,
+			U256::default(),
+			None,
+		));
+
+		assert_ok!(EVM::call(
+			Origin::root(),
+			H160::default(),
+			H160::from_str("1000000000000000000000000000000000000002").unwrap(),
+			Vec::new(),
+			U256::default(),
+			1000000,
+			U256::default(),
+			None,
+		));
+	});
+}
+
+#[cfg(not(feature = "debug"))]
+#[test]
+fn fail_call_return_forbidden() {
 	new_test_ext().execute_with(|| {
 		assert_err!(EVM::call(
 			Origin::root(),


### PR DESCRIPTION
Add debug feature that can enable the VM execution from polkadot.js

Ref: #27 